### PR TITLE
Changes around concordance data

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,9 +60,15 @@ func main() {
 		Desc:   "Cache file name",
 		EnvVar: "CACHE_FILE_NAME",
 	})
+	berthaURL := app.String(cli.StringOpt{
+		Name:   "bertha-url",
+		Value:  "https://bertha.ig.ft.com/view/publish/gss/1k7GHf3311hyLBsNgoocRRkHs7pIhJit0wQVReFfD_6w/orgs",
+		Desc:   "Bertha URL to concordance file",
+		EnvVar: "BERTHA_URL",
+	})
 
 	app.Action = func() {
-		if err := runApp(*v1URL, *fsURL, *port, *cacheFileName); err != nil {
+		if err := runApp(*v1URL, *fsURL, *port, *cacheFileName, *berthaURL); err != nil {
 			log.Fatal(err)
 		}
 		log.Println("Started app")
@@ -71,7 +77,7 @@ func main() {
 	app.Run(os.Args)
 }
 
-func runApp(v1URL, fsURL string, port int, cacheFile string) error {
+func runApp(v1URL, fsURL string, port int, cacheFile string, berthaURL string) error {
 	if v1URL == "" {
 		return errors.New("v1 Organisation transformer URL must be provided")
 	}
@@ -85,6 +91,7 @@ func runApp(v1URL, fsURL string, port int, cacheFile string) error {
 		client:         httpClient,
 		uuidV1toUUIDV2: make(map[string]string),
 		uuidV2toUUIDV1: make(map[string]map[string]struct{}),
+		berthaURL: berthaURL,
 	}
 
 	repo := &httpOrgsRepo{client: httpClient}

--- a/util.go
+++ b/util.go
@@ -1,21 +1,11 @@
 package main
 
 import (
-	"crypto/md5"
 	"github.com/pborman/uuid"
 )
 
-var hasher = md5.New()
-var emptyUUID = uuid.UUID{}
-
 func v1ToUUID(v1id string) string {
 	return uuid.NewMD5(uuid.UUID{}, []byte(v1id)).String()
-}
-
-func v2ToUUID(fsid string) string {
-	md5data := md5.Sum([]byte(fsid))
-	hasher.Reset()
-	return uuid.NewHash(hasher, emptyUUID, md5data[:], 3).String()
 }
 
 func canonical(uuids ...string) (c string, index int) {


### PR DESCRIPTION
- Using correct curated concordance: https://bertha.ig.ft.com/view/publish/gss/1k7GHf3311hyLBsNgoocRRkHs7pIhJit0wQVReFfD_6w/orgs
- Adding some validations for missing data
- Extracted berthaURL as a command argument
