### PR TITLE
Added all types to output 

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -3,12 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Financial-Times/go-fthealth/v1a"
-	log "github.com/Sirupsen/logrus"
-	"github.com/gorilla/mux"
 	"io"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/Financial-Times/go-fthealth/v1a"
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
 )
 
 type orgsHandler struct {

--- a/handler_test.go
+++ b/handler_test.go
@@ -73,7 +73,7 @@ func TestGetHandler(t *testing.T) {
 			mockOrgsService{isFound: true, canonicalUUID: knownUUID, nonCanonicalUUID: alternativeUUID},
 			mockHTTPClient{},
 			http.StatusOK,
-			`{"uuid":"c7e492d9-b8f1-4318-aed8-8103df4e42a9", "type":"", "properName":"", "prefLabel":"", "alternativeIdentifiers":{"uuids":["c7e492d9-b8f1-4318-aed8-8103df4e42a9", "6a5a939c-e166-4a38-b114-23fcd6cb1cf1"]}}`,
+			`{"uuid":"c7e492d9-b8f1-4318-aed8-8103df4e42a9", "type":"", "types":null, "properName":"", "prefLabel":"", "alternativeIdentifiers":{"uuids":["c7e492d9-b8f1-4318-aed8-8103df4e42a9", "6a5a939c-e166-4a38-b114-23fcd6cb1cf1"]}}`,
 			map[string]string{"Content-Type": "application/json"}},
 		{"Redirect",
 			newRequest("GET", fmt.Sprintf("/transformers/organisations/%s", alternativeUUID), "application/json", nil),

--- a/main.go
+++ b/main.go
@@ -4,18 +4,19 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/Financial-Times/go-fthealth/v1a"
-	status "github.com/Financial-Times/service-status-go/httphandlers"
-	log "github.com/Sirupsen/logrus"
-	"github.com/gorilla/mux"
-	"github.com/jawher/mow.cli"
-	"github.com/sethgrid/pester"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"time"
+
+	"github.com/Financial-Times/go-fthealth/v1a"
+	status "github.com/Financial-Times/service-status-go/httphandlers"
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
+	"github.com/jawher/mow.cli"
+	"github.com/sethgrid/pester"
 )
 
 type concorder interface {
@@ -65,7 +66,7 @@ func main() {
 		EnvVar: "BERTHA_URL",
 	})
 
-	redirectLocationUrl := app.String(cli.StringOpt{
+	redirectLocationURL := app.String(cli.StringOpt{
 		Name:   "redirect-base-url",
 		Value:  "/transformers/organisations/",
 		Desc:   "Redirect url",
@@ -73,7 +74,7 @@ func main() {
 	})
 
 	app.Action = func() {
-		if err := runApp(*v1URL, *fsURL, *port, *cacheFileName, *berthaURL, *redirectLocationUrl); err != nil {
+		if err := runApp(*v1URL, *fsURL, *port, *cacheFileName, *berthaURL, *redirectLocationURL); err != nil {
 			log.Fatal(err)
 		}
 		log.Println("Started app")

--- a/model.go
+++ b/model.go
@@ -2,7 +2,8 @@ package main
 
 type combinedOrg struct {
 	UUID                   string                 `json:"uuid"`
-	Type                   string                 `json:"type"`
+	PrimaryType            string                 `json:"type"`
+	TypeHierarchy          []string               `json:"types"`
 	ProperName             string                 `json:"properName"`
 	PrefLabel              string                 `json:"prefLabel"`
 	LegalName              string                 `json:"legalName,omitempty"`

--- a/service.go
+++ b/service.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
-	"github.com/boltdb/bolt"
 	"regexp"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/boltdb/bolt"
 )
 
 const (
@@ -264,11 +265,11 @@ func storeOrgToCache(db *bolt.DB, cacheToBeWritten map[string]*combinedOrg, wg *
 				return err
 			}
 			if combinedOrgResult.AlternativeIdentifiers.Uuids != nil && len(combinedOrgResult.AlternativeIdentifiers.Uuids) > 0 {
-				for _, alternativeUuid := range combinedOrgResult.AlternativeIdentifiers.Uuids {
-					if alternativeUuid == combinedOrgResult.UUID {
+				for _, alternativeUUID := range combinedOrgResult.AlternativeIdentifiers.Uuids {
+					if alternativeUUID == combinedOrgResult.UUID {
 						continue
 					}
-					err = bucket.Put([]byte(alternativeUuid), marshalledCombinedOrg)
+					err = bucket.Put([]byte(alternativeUUID), marshalledCombinedOrg)
 					if err != nil {
 						return err
 					}

--- a/service.go
+++ b/service.go
@@ -216,7 +216,7 @@ func (s *orgServiceImpl) loadCombinedOrgs(db *bolt.DB) error {
 			s.list = append(s.list, combinedOrgResult.UUID)
 
 			//save to cache only concorded orgs. For non concorded orgs combinedOrgResult will only contain UUID
-			if combinedOrgResult.Type != "" {
+			if combinedOrgResult.PrimaryType != "" {
 				combinedOrgCache[combinedOrgResult.UUID] = combinedOrgResult
 			}
 

--- a/service_test.go
+++ b/service_test.go
@@ -23,8 +23,12 @@ const (
 	concV2UUID    = "9eb50f88-5b6e-33f9-a3f7-30e2f3f6cc4e"
 	canonicalUUID = concV1UUID2
 
-	orgType = "Organisation"
+	primaryTypeOrg = "Organisation"
+	primaryTypePub = "PublicCompany"
 )
+
+var orgTypes = []string{"Thing", "Concept", "Organisation"}
+var pubTypes = []string{"Thing", "Concept", "Organisation", "Company", "PublicCompany"}
 
 type ByID []idEntry
 
@@ -39,7 +43,11 @@ func (s ByID) Less(i, j int) bool {
 }
 
 func TestGetOrganisations(t *testing.T) {
+	getOrganisations(t, primaryTypeOrg, orgTypes)
+	getOrganisations(t, primaryTypePub, pubTypes)
+}
 
+func getOrganisations(t *testing.T, primaryType string, typeHierarchy []string) {
 	con := &mockBerthaConcorder{
 		uuidV1toUUIDV2: map[string]string{concV1UUID1: concV2UUID, concV1UUID2: concV2UUID},
 		uuidV2toUUIDV1: map[string]map[string]struct{}{concV2UUID: map[string]struct{}{concV1UUID1: struct{}{}, concV1UUID2: struct{}{}}},
@@ -47,33 +55,38 @@ func TestGetOrganisations(t *testing.T) {
 
 	repo := &mockOrgsRepo{v1Orgs: map[string]combinedOrg{
 		v1TransURL + "/" + v1UUID: combinedOrg{
-			UUID:       v1UUID,
-			ProperName: "V1 Name 1",
-			Type:       orgType,
+			UUID:                   v1UUID,
+			ProperName:             "V1 Name 1",
+			PrimaryType:            primaryTypeOrg,
+			TypeHierarchy:          orgTypes,
 			AlternativeIdentifiers: alternativeIdentifiers{Uuids: []string{v1UUID}, TME: []string{v1UUID + "base64"}},
 		},
 		v1TransURL + "/" + concV1UUID1: combinedOrg{
-			UUID:       concV1UUID1,
-			ProperName: "Conc V1 Name 1",
-			Type:       orgType,
+			UUID:                   concV1UUID1,
+			ProperName:             "Conc V1 Name 1",
+			PrimaryType:            primaryTypeOrg,
+			TypeHierarchy:          orgTypes,
 			AlternativeIdentifiers: alternativeIdentifiers{Uuids: []string{concV1UUID1}, TME: []string{concV1UUID1 + "base64"}},
 		},
 		v1TransURL + "/" + concV1UUID2: combinedOrg{
-			UUID:       concV1UUID2,
-			ProperName: "Conc V1 Name 2",
-			Type:       orgType,
+			UUID:                   concV1UUID2,
+			ProperName:             "Conc V1 Name 2",
+			PrimaryType:            primaryTypeOrg,
+			TypeHierarchy:          orgTypes,
 			AlternativeIdentifiers: alternativeIdentifiers{Uuids: []string{concV1UUID2}, TME: []string{concV1UUID2 + "base64"}},
 		},
 	},
 		v2Orgs: map[string]combinedOrg{
 			v2TransURL + "/" + v2UUID: combinedOrg{
-				UUID: v2UUID,
-				Type: orgType,
+				UUID:                   v2UUID,
+				PrimaryType:            primaryTypeOrg,
+				TypeHierarchy:          orgTypes,
 				AlternativeIdentifiers: alternativeIdentifiers{Uuids: []string{v2UUID}, FactsetIdentifier: v2UUID + "base64"},
 			},
 			v2TransURL + "/" + concV2UUID: combinedOrg{
-				UUID: concV1UUID2,
-				Type: orgType,
+				UUID:                   concV1UUID2,
+				PrimaryType:            primaryType,
+				TypeHierarchy:          typeHierarchy,
 				AlternativeIdentifiers: alternativeIdentifiers{Uuids: []string{concV2UUID}, FactsetIdentifier: concV2UUID + "base64"},
 			},
 		}}
@@ -126,8 +139,9 @@ func TestGetOrganisations(t *testing.T) {
 		sort.Strings(concordedOrg.AlternativeIdentifiers.Uuids)
 		sort.Strings(concordedOrg.AlternativeIdentifiers.TME)
 		assert.EqualValues(t, combinedOrg{
-			UUID: canonicalUUID,
-			Type: orgType,
+			UUID:          canonicalUUID,
+			PrimaryType:   primaryType,
+			TypeHierarchy: typeHierarchy,
 			AlternativeIdentifiers: alternativeIdentifiers{
 				FactsetIdentifier: concV2UUID + "base64",
 				TME:               []string{concV1UUID2 + "base64", concV1UUID1 + "base64"},

--- a/service_test.go
+++ b/service_test.go
@@ -3,11 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (


### PR DESCRIPTION
* the transformer now returns every type in the org taxonomy hierarchy received from it's sources (v1, v2)
* ties in with the changes in
  * v2-transformer in internal git: org-transformer/pull-requests/7/commits
  * https://github.com/Financial-Times/v1-orgs-transformer/pull/7