### PR TITLE
Set pod affinity and memory limits

### DIFF
--- a/helm/composite-orgs-transformer/templates/deployment.yaml
+++ b/helm/composite-orgs-transformer/templates/deployment.yaml
@@ -18,6 +18,16 @@ spec:
         app: {{ .Values.service.name }}
         visualize: "true" 
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ .Values.service.name }}
+            topologyKey: "kubernetes.io/hostname"
       containers: 
       - name: {{ .Values.service.name }} 
         image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"

--- a/helm/composite-orgs-transformer/values.yaml
+++ b/helm/composite-orgs-transformer/values.yaml
@@ -8,8 +8,10 @@ image:
   repository: coco/composite-orgs-transformer
   pullPolicy: IfNotPresent
 resources:
+  requests:
+    memory: 2Gi
   limits:
-    memory: 4Gi
+    memory: 3Gi
 persistent:
   capacity: 5Gi
 env:


### PR DESCRIPTION
I have only updated this app with the helm changes around pod affinity and memory limits. This is because the healthcheck and gtg have never been implemented and at this point it will be more hassle than its worth because this app will hopefully be decommed by Q2 2018